### PR TITLE
Added dynamic path fallback.

### DIFF
--- a/util/proxy_actions.py
+++ b/util/proxy_actions.py
@@ -1,6 +1,7 @@
 """performs black magic on the dragonfly actions objects to force them to
    forward their actions to a remote server."""
 
+import os
 import pyparsing
 
 import communications
@@ -20,8 +21,14 @@ def _get_key_symbols():
     with open("keys.txt") as keyfile:
       return [line.strip() for line in keyfile]
   except Exception:
-    with open("C:\\NatLink\\NatLink\\MacroSystem\\keys.txt") as keyfile:
-      return [line.strip() for line in keyfile]
+    try:
+      path = os.path.dirname(os.path.abspath(__file__))
+      path = os.path.join(path, "keys.txt")
+      with open(path) as keyfile:
+        return [line.strip() for line in keyfile]
+    except Exception:
+      with open("C:\\NatLink\\NatLink\\MacroSystem\\keys.txt") as keyfile:
+        return [line.strip() for line in keyfile]
 
 _modifier_keys = {
         "a": "alt",


### PR DESCRIPTION
If the user keeps their Aenea files outside the MacroSystem folder (as I do), the working path for the Dragonfly scripts will be the MacroSystem folder and therefore not contain the keys.txt file. The extra fallback fetches the modules own path, and tries to find the file there instead.
This could also be used as the first alternative instead, as it should work in all situations.
