### PR TITLE
Don't create a ProxyText object if there's no text in the buffer.

### DIFF
--- a/client/aenea_client.py
+++ b/client/aenea_client.py
@@ -172,7 +172,8 @@ class AeneaClient(tk.Tk):
             if key in LITERAL_KEYS:
                 self.aenea_buffer.append(key)
             else:
-                self.to_send.append(aenea.ProxyText(''.join(self.aenea_buffer)))
+                if self.aenea_buffer:
+                    self.to_send.append(aenea.ProxyText(''.join(self.aenea_buffer)))
 
                 try:
                     self.to_send.append(aenea.ProxyKey(key))


### PR DESCRIPTION
The pathological case here is when using Dragon's 'delete that' command.  It will send a series of 'backspace' keys.  Without this change, every 'backspace' key press will be preceded by an empty ProxyText call, effectively doubling the amount of RPC calls we'd make.
