### PR TITLE
Default to accepting commands whether or not client is active.

### DIFF
--- a/aenea.json.example
+++ b/aenea.json.example
@@ -5,5 +5,5 @@
     "use_multiple_actions": true,
     "screen_resolution": [6400, 1440],
     "project_root": "C:\\NatLink\\NatLink\\MacroSystem",
-    "restrict_proxy_to_aenea_client": true
+    "restrict_proxy_to_aenea_client": false
 }


### PR DESCRIPTION
Just helped someone troubleshoot this via email. I'm defaulting to the most generous option -- work TOO often. Once users have the system working they can change this setting if desired.
