### PR TITLE
ReloadGrammarsRule fix

### DIFF
--- a/client/_aenea.py
+++ b/client/_aenea.py
@@ -85,8 +85,9 @@ class ReloadGrammarsRule(dragonfly.CompoundRule):
         path = 'C:\\NatLink\\NatLink\\MacroSystem'
         for g in os.listdir(path):
             fn = os.path.join(path, g)
-            with open(fn, 'a') as fd:
-                fd.write(' ')
+            if os.path.isfile(fn):
+                with open(fn, 'a') as fd:
+                    fd.write(' ')
 
 
 server_list = dragonfly.DictList('aenea servers')


### PR DESCRIPTION
fix for #57

ReloadGrammarsRule in the aenea grammar should only append " " to files when executed. Method previously tried to open directories as files for writing which caused errors on some systems. (win xp)
