### PR TITLE
exposed xdotool delay via server config

### DIFF
--- a/server/linux_x11/config.py.example
+++ b/server/linux_x11/config.py.example
@@ -29,3 +29,7 @@ PLUGIN_PATH = ["plugins"]
 # least enables users to configure it to work properly, this will become
 # workable.
 ENABLE_XSEL = False
+
+# xdotool delay.  Setting this value greater than zero may help solve some text
+# input issues.  Obviously this setting does not apply when ENABLE_XSEL = True.
+XDOTOOL_DELAY = 0

--- a/server/linux_x11/server_x11.py
+++ b/server/linux_x11/server_x11.py
@@ -336,8 +336,11 @@ def write_text(text, paste=False, _xdotool=None):
             run_command('-x', executable='xsel')
         else:
             flush_xdotool(_xdotool)
-            write_command(text, arguments='type --file - --delay 0')
 
+            write_command(
+                text,
+                arguments='type --file - --delay %d' % config.XDOTOOL_DELAY
+            )
 
 def click_mouse(
         button,


### PR DESCRIPTION
Exposes xdotool keystroke delay via server config.  This setting was mentioned by @calmofthestorm in #28.  I needed the feature a bit sooner :)

If needed I will add code to default the delay to 0 if the XDOTOOL_DELAY option is not set in the config.  I initially decided not to as not to add bloat.
