### PR TITLE
Restore the correct return code in make_grammar_commands

### DIFF
--- a/client/aenea/configuration.py
+++ b/client/aenea/configuration.py
@@ -180,7 +180,7 @@ def make_grammar_commands(module_name, mapping, config_key='commands', alias = A
         # Allow users to nuke a command with !
         if not user_phrase.startswith('!'):
             commands[user_phrase] = mapping[default_phrase]
-    return commands
+    return alias.make_mapping_spec(commands)
 
 
 def make_local_disable_context(grammar_conf):


### PR DESCRIPTION
The wrong one was copied accidentally during a merge; this fixes a bug that caused
aliases to have no effect.
