### PR TITLE
OSX Fixes

### DIFF
--- a/server/osx/server_osx.py
+++ b/server/osx/server_osx.py
@@ -297,6 +297,16 @@ def map_window_properties(properties):
 
 
 def get_geometry(window_id=None):
+    p = get_window_properties(window_id)
+    frame = {'x': p['posn'][0],
+            'y': p['posn'][1],
+            'width': p['ptsz'][0],
+            'height': p['ptsz'][1]} 
+
+    return frame  # what to do about screen?
+
+
+def get_window_properties(window_id=None):
     if window_id is None:
         window_id, _ = get_active_window()
 
@@ -312,12 +322,7 @@ def get_geometry(window_id=None):
     properties = script.run()
 
     p = map_window_properties(properties)
-
-    return {'x': p['posn'][0],
-            'y': p['posn'][1],
-            'width': p['ptsz'][0],
-            'height': p['ptsz'][1]}  # what to do about screen?
-
+    return p
 
 def transform_relative_mouse_event(event):
     geo = get_geometry()
@@ -331,22 +336,7 @@ def get_context():
        at least include title and executable.'''
 
     window_id, window_title = get_active_window()
-    if window_id is None:
-        return {}
-
-    cmd = '''tell application "System Events" to tell application process "%s"
-        try
-            get properties of window 1
-        on error errmess
-            log errmess
-        end try
-    end tell
-    ''' % window_id
-    script = applescript.AppleScript(cmd)
-    properties = {}
-    props = script.run()
-
-    properties = map_window_properties(props)
+    properties = get_window_properties(window_id)
     properties['id'] = window_id
     properties['title'] = window_title
 

--- a/server/osx/test-client.py
+++ b/server/osx/test-client.py
@@ -58,6 +58,7 @@ def test_click_mouse(distobj):
     distobj.click_mouse(button='left', count=2)
     distobj.click_mouse(button='wheelup', count=2)
     distobj.click_mouse(button='right')
+    distobj.click_mouse(button='left')
 
 
 def test_move_mouse(distobj):
@@ -109,6 +110,7 @@ def all_tests(distobj):
     test_move_mouse(distobj)
     test_mouse_drag(distobj)
     test_pause(distobj)
+    distobj.key_press(key='escape')
     distobj.get_context()
 
 


### PR DESCRIPTION
Trying this again - https://github.com/dictation-toolbox/aenea/pull/88 contained a bug that was the result of just stringifying the whole result of get_context. This is fixed here: https://github.com/dictation-toolbox/aenea/compare/master...sweetmandm:master#diff-6e6d0904bb756da30338881811b10437R343 where the breaking values are stringified individually.

***
This solves some OS X server issues I encountered where it failed executing commands or passing the tests in test-client.py.

Only 5f48d40 holds actual fixes. The other commit is more cosmetic/refactor (it was difficult to tell if the two applescript sections were identical; they were.)

Only tested on Yosemite 10.10.3