### PR TITLE
Add assertions that we use positional XOR kw args in json-rpc and batch.

### DIFF
--- a/client/aenea/communications.py
+++ b/client/aenea/communications.py
@@ -101,6 +101,10 @@ class Proxy(object):
 
     def __getattr__(self, meth):
         def call(*a, **kw):
+            # Cannot use both positional and keyword arguments
+            # (according to JSON-RPC spec.)
+            assert not (a and kw)
+
             return self._execute_batch([(meth, a, kw)])
         return call
 
@@ -123,6 +127,10 @@ class BatchProxy(object):
 
     def __getattr__(self, key):
         def call(*a, **kw):
+            # Cannot use both positional and keyword arguments
+            # (according to JSON-RPC spec.)
+            assert not (a and kw)
+
             if not key.startswith('_'):
                 self._commands.append((key, a, kw))
         return call

--- a/server/linux_x11/server_x11.py
+++ b/server/linux_x11/server_x11.py
@@ -480,6 +480,12 @@ def multiple_actions(actions):
     for (method, parameters, optional) in actions:
         commands = list_rpc_commands()
         if method in commands:
+            # JSON-RPC forbids specifying both optional and parameters.
+            # Since multiple_actions is trying to mimic something like
+            # Multicall except with sequential ordering and abort,
+            # we enforce it here.
+            assert not (parameters and optional)
+
             commands[method](*parameters, _xdotool=xdotool, **optional)
         else:
             break


### PR DESCRIPTION
JSON-RPC allows the use of either positional or keyword arguments to methods, but a given call may not use both. Batch calls now assert that this is the case -- calling a method on a batch with both positional arguments and keyword arguments will now result in an assertion failure. Note that this behavior would have failed before as well on the client if you are using the batch, so this does not change semantics or protocol, just makes it explicit.

HOWEVER, if you wrote a custom client that directly called the multiple_actions RPC bypassing the batch and proxy, this could break that.