### PR TITLE
Added missing super-constructor call

### DIFF
--- a/client/aenea/wrappers.py
+++ b/client/aenea/wrappers.py
@@ -280,6 +280,7 @@ class ContextAction(ActionBase):
     def __init__(self, default=None, actions=[]):
         self.actions = actions
         self.default = default
+        ActionBase.__init__(self)
 
     def add_context(self, context, action):
         self.actions.append((context, action))


### PR DESCRIPTION
I discovered this when trying to use the `ContextAction` class. Just calling `ActionBase.__init__(self)` in `ContextAction.__init__` fixed it.