### PR TITLE
fix Key delays for OS X

### DIFF
--- a/server/osx/server_osx.py
+++ b/server/osx/server_osx.py
@@ -388,7 +388,7 @@ def key_press(
     if count_delay is None or count < 2:
         delay = ''
     else:
-        delay = 'delay %i ' % (count_delay / 1000.0)
+        delay = 'delay %0.2f ' % count_delay
 
     if modifiers and hasattr(modifiers, 'lower'):
         modifiers = [modifiers]


### PR DESCRIPTION
Delays are specified in hundredths of seconds in Key Actions. These are then
converted to seconds in the Aenea JSON-RPC specification. AppleScript delay
also expects seconds and supports non-integer values.