### PR TITLE
removed the import and mock of FormatState and Word

### DIFF
--- a/client/aenea/dragonfly_mock.py
+++ b/client/aenea/dragonfly_mock.py
@@ -116,9 +116,6 @@ class Empty:
 class FocusWindow:
    pass
 
-class FormatState:
-   pass
-
 class Function:
    pass
 
@@ -225,7 +222,4 @@ class Typeable:
    pass
 
 class WaitWindow:
-   pass
-
-class Word:
    pass

--- a/client/aenea/wrappers.py
+++ b/client/aenea/wrappers.py
@@ -45,7 +45,6 @@ try:
        ElementBase,
        Empty,
        FocusWindow,
-       FormatState,
        Function,
        HardwareInput,
        Integer,
@@ -83,8 +82,7 @@ try:
        Text,
        Typeable,
        WaitWindow,
-       Window,
-       Word
+       Window
        )
 except ImportError:
     from aenea.dragonfly_mock import (
@@ -109,7 +107,6 @@ except ImportError:
        ElementBase,
        Empty,
        FocusWindow,
-       FormatState,
        Function,
        HardwareInput,
        Integer,
@@ -147,8 +144,7 @@ except ImportError:
        Text,
        Typeable,
        WaitWindow,
-       Window,
-       Word
+       Window
        )
 
 


### PR DESCRIPTION
Dragonfly removed FormatState and Word on commit 4eed31c causing an import error
on the latest version. This commit removes the mock class and the imports from
dragonfly.