### PR TITLE
Search for aenea.json config in the NatLink user directory.

### DIFF
--- a/client/aenea/config.py
+++ b/client/aenea/config.py
@@ -20,12 +20,16 @@ import os
 import time
 
 try:
-    import dragonfly
+    import dragonfly, natlinkmain
 except ImportError:
     import dragonfly_mock as dragonfly
 
-
-STARTING_PROJECT_ROOT = 'C:\\NatLink\\NatLink\\MacroSystem'
+try:
+    STARTING_PROJECT_ROOT = natlinkmain.userDirectory
+except (AttributeError, NameError):
+    # AttributeError is for older NatLink that may not have the userDirectory value.
+    # NameError is if the natlinkmain module can't be loaded (e.g., running in tests).
+    STARTING_PROJECT_ROOT = 'C:\\NatLink\\NatLink\\MacroSystem'
 
 _configuration = {
     'project_root': STARTING_PROJECT_ROOT,


### PR DESCRIPTION
NatLink 4.1oscar introduced a new configuration item for storing NatLink files created by the user, called the UserDirectory setting. Prior to this change any custom files, such as Dragonfly grammars, needed to be stored in NatLink's MacroSystem directory. However, this directory is intended to be used for NatLink internals and mixing in user-specific files creates a mess. Using the newer UserDirectory setting is now the golden path for storing user-specific files.