### PR TITLE
ignore IOError in get_context

### DIFF
--- a/server/linux_x11/x11_xdotool.py
+++ b/server/linux_x11/x11_xdotool.py
@@ -264,7 +264,7 @@ class XdotoolPlatformRpcs(AbstractAeneaPlatformRpcs):
                 cmdline_path = '/proc/%s/cmdline' % properties['pid']
                 with open(cmdline_path) as fd:
                     properties['cmdline'] = fd.read().replace('\x00', ' ').strip()
-            except OSError:
+            except (IOError, OSError):
                 pass
         else:
             self.logger.warn('pid not set. properties: %s' % properties)


### PR DESCRIPTION
I got a lot of IOErrors in natlink, and as far as I can see they should just be ignored.