### PR TITLE
Support unicode characters in server.

### DIFF
--- a/server/linux_x11/x11_xdotool.py
+++ b/server/linux_x11/x11_xdotool.py
@@ -175,7 +175,7 @@ class XdotoolPlatformRpcs(AbstractAeneaPlatformRpcs):
         self.logger.debug(
                 'echo \'%s\' | %s %s' % (message, executable, arguments))
         with os.popen('%s %s' % (executable, arguments), 'w') as fd:
-            fd.write(message)
+            fd.write(message.encode('utf-8'))
 
     def flush_xdotool(self, actions):
         if actions:


### PR DESCRIPTION
UTF-8 encode text sent to the server before passing it through a pipe to xdotool. This should allow the use of special characters.