### PR TITLE
A few tweaks to support other module loaders

### DIFF
--- a/client/_aenea.py
+++ b/client/_aenea.py
@@ -24,8 +24,11 @@ import sys
 
 import dragonfly
 
-# Internal NatLink module for reloading grammars.
-import natlinkmain
+try:
+    # Internal NatLink module for reloading grammars.
+    import natlinkmain
+except ImportError:
+    natlinkmain = None
 
 try:
     import aenea
@@ -92,8 +95,9 @@ def reload_code():
     dir_reload_blacklist = set(["core"])
     macro_dir = "C:\\NatLink\\NatLink\\MacroSystem"
 
-    # Unload all grammars.
-    natlinkmain.unloadEverything()
+    # Unload all grammars if natlinkmain is available.
+    if natlinkmain:
+        natlinkmain.unloadEverything()
 
     # Unload all modules in macro_dir except for those in directories on the
     # blacklist.
@@ -120,8 +124,9 @@ def reload_code():
                 del sys.modules[name]
 
     try:
-        # Reload the top-level modules in macro_dir.
-        natlinkmain.findAndLoadFiles()
+        # Reload the top-level modules in macro_dir if natlinkmain is available.
+        if natlinkmain:
+            natlinkmain.findAndLoadFiles()
     except Exception as e:
         print "reloading failed: {}".format(e)
     else:

--- a/client/aenea/config.py
+++ b/client/aenea/config.py
@@ -20,7 +20,14 @@ import os
 import time
 
 try:
-    import dragonfly, natlinkmain
+    # Import natlinkmain separately so that it isn't required to use Aenea with
+    # module loaders for other engines.
+    import natlinkmain
+except ImportError:
+    pass
+
+try:
+    import dragonfly
 except ImportError:
     import dragonfly_mock as dragonfly
 


### PR DESCRIPTION
These are some minor changes I needed to make to use Aenea with my dragonfly fork's Pocket Sphinx engine. This mainly involves making `natlinkmain` optional. The Pocket Sphinx engine uses a modified version of the WSR module loader, so these changes should work for WSR as well without natlink installed.