### PR TITLE
Revert "Revert "Add micro delay with OSX keypresses" seems to be a ne…

### DIFF
--- a/server/osx/server_osx.py
+++ b/server/osx/server_osx.py
@@ -459,7 +459,10 @@ def write_text(text, paste=False):
     if text:
         script = applescript.AppleScript('''
         tell application "System Events"
-            keystroke "{text}"
+          repeat with i from 1 to count characters of "{text}"
+            keystroke (character i of "{text}")
+            delay 0.0002
+          end repeat
         end tell
         '''.format(text=text))
         script.run()


### PR DESCRIPTION
…cessary"

This reverts commit f07b6ecefd579d98a6e75d5db7a636f85bf09cfa.

 I am re-reverting this because I realised that MacVim and VimR, among other
    applications, often missed big chunks of `Text`. I originally reverted
    this change in #162 on github.
