### PR TITLE
Add Travis CI integration for the client unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+dist: trusty
+language: python
+
+sudo: false
+
+install:
+ - travis_retry pip install --upgrade pip
+ - travis_retry pip install --upgrade six
+ - travis_retry pip install --upgrade pyflakes
+ - travis_retry pip install -r client/requirements.txt
+
+script:
+ - PATH="${HOME}/.local/bin:${PATH}" python lint.py
+ - PYTHONPATH="client:${PYTHONPATH}" python test_runner.py `find client/test/test_*.py | xargs`

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://travis-ci.org/dictation-toolbox/aenea.svg?branch=master
+    :target: https://travis-ci.org/dictation-toolbox/aenea
+
 =================
 Aenea
 =================

--- a/lint.py
+++ b/lint.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import os
+import sys
+
+
+def main():
+    ok = True
+
+    with os.popen('find -type f | egrep ".py$"') as fd:
+        python_files = set(fd)
+    with open('.nopyflakes') as fd:
+        python_files -= set(fd)
+
+    for filename in python_files:
+        if os.system('pyflakes %s' % filename) != 0:
+            ok = False
+
+    if ok:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/test_runner.py
+++ b/test_runner.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+
+import os
+import sys
+
+
+def main():
+    fail = False
+
+    for fn in sys.argv[1:]:
+        fail = os.system('python %s' % fn) != 0 or fail
+
+    if fail:
+        sys.exit(-1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Aenea's automated tests are, sadly, not great. We have a simple
integration test for the server that relies on X11, some basic unit
tests for the client library, and a bunch of untested code.

I don't think I'll be able to spend the time fully fixing this,
unfortunately, but we can at least set up CI for the tests we have to
prevent them from bit rotting again, and so that if other contributors
wish to add tests they can more easily do so.

I've also decided to start enforcing pyflakes clean for all new PRs
going forward; there is a list of exclusions in .nopyflakes for files
that would be impractical to fix for the time being. New PRs must not
introduce new pyflakes errors.

Both pyflakes and the client-side unit tests, such as they are, will now
run in Travis.