### PR TITLE
Fix missing 'equals' translations for Linux X11 server

### DIFF
--- a/server/linux_x11/x11_libxdo.py
+++ b/server/linux_x11/x11_libxdo.py
@@ -89,6 +89,7 @@ _KEY_TRANSLATION = {
     'dquote': 'quotedbl',
     'enter': 'Return',
     'equal': 'equal',
+    'equals': 'equal',
     'exclamation': 'exclam',
     'hash': 'numbersign',
     'hyphen': 'minus',

--- a/server/linux_x11/x11_xdotool.py
+++ b/server/linux_x11/x11_xdotool.py
@@ -90,6 +90,7 @@ _KEY_TRANSLATION = {
     'dquote': 'quotedbl',
     'enter': 'Return',
     'equal': 'equal',
+    'equals': 'equal',
     'exclamation': 'exclam',
     'hash': 'numbersign',
     'hyphen': 'minus',


### PR DESCRIPTION
There are missing key translations from 'equals' to 'equal'. @esc123 discovered this bug while testing https://github.com/synkarius/caster/pull/316. The debug output shows the following if the server receives "equals":
```
[DEBUG ] [aenea.XdotoolPlatformRpcs] xdotool key equals
(symbol) No such key name 'equals'. Ignoring it.
(symbol) No such key name 'equals'. Ignoring it.
```

I've added the missing dict entries in the files for xdotool and libxdo.