### PR TITLE
aenea server (x11): requires xprop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ Server (Linux X11)
 
 1) Copy ``config.py.example`` to ``config.py``. Edit to suit. The default assumes you are using a host-only adapter for the VM which is NOT the default. Note that the HOST/PORT here must work with those specified in the client-side config (in most cases they will need to be identical).
 
-2) Install the dependencies. Versions I used are in parentheses for reference; you probably don't need these exact versions for it to work. Install ``jsonrpclib`` (0.1.7), ``xdotool`` (3.20140213.1), ``xsel`` (1.2.0; optional but recommended), and ``yapsy`` (1.10.223-1; optional but recommended if you want server-side plugin support). Some window managers (``xmonad``) may require you to enable extended window manager hints for getcontext to work properly. On Awesome, it works out of the box.
+2) Install the dependencies. Versions I used are in parentheses for reference; you probably don't need these exact versions for it to work. Install ``jsonrpclib`` (0.1.7), ``xdotool`` (3.20140213.1), ``xprop`` (1.2.3), ``xsel`` (1.2.0; optional but recommended), and ``yapsy`` (1.10.223-1; optional but recommended if you want server-side plugin support). Some window managers (``xmonad``) may require you to enable extended window manager hints for getcontext to work properly. On Awesome, it works out of the box.
 
 3) Edit the server's ``config.py.example`` to specify the host and port it should listen on.
 


### PR DESCRIPTION
Aenea with X11, without xprop won't work:

```
Feb 18 23:37:48 Petunia server.py[8086]: 2019-02-18 23:37:48,476 [DEBUG ] [aenea.XdotoolPlatformRpcs] xprop -id 27262992 | <server>
Feb 18 23:37:48 Petunia server.py[8086]: sh: xprop: command not found
Feb 18 23:37:48 Petunia server.py[8086]: 2019-02-18 23:37:48,479 [WARNING] [aenea.XdotoolPlatformRpcs] pid not set. properties: {'executable': None, 'id': 27262992, 'title': 'Mozilla Firefox'}
```