### PR TITLE
teach aenea about micState

### DIFF
--- a/server/core.py
+++ b/server/core.py
@@ -127,6 +127,7 @@ class AbstractAeneaPlatformRpcs(object):
             'move_mouse': self.move_mouse,
             'pause': self.pause,
             'notify': self.notify,
+            'micState': self.micState,
         }
 
     @abc.abstractmethod
@@ -224,6 +225,14 @@ class AbstractAeneaPlatformRpcs(object):
         """
         Send a message to the desktop to be displayed in a notification window.
         :param str message: message to send to the desktop.
+        :return: This function always returns None.
+        """
+        raise NotImplementedError()
+
+    def micState(self, state):
+        """
+        Send a message to the desktop representing the current microphone state.
+        :param str state: state of the microphone
         :return: This function always returns None.
         """
         raise NotImplementedError()

--- a/server/linux_x11/x11_xdotool.py
+++ b/server/linux_x11/x11_xdotool.py
@@ -285,6 +285,20 @@ class XdotoolPlatformRpcs(AbstractAeneaPlatformRpcs):
         except Exception as e:
             self.logger.warn('failed to start notify-send process: %s' % e)
 
+    def micState(self, state):
+        '''Send the microphone state to DBUS'''
+        self.logger.debug("dbus-send /dictationtoolbox/aenea/microphonestate"
+                          "dictationtoolbox.aenea.microphonestate 'string:%s'" % state)
+        try:
+            subprocess.Popen(['dbus-send',
+                    '/dictationtoolbox/aenea/microphonestate',
+                    'dictationtoolbox.aenea.microphonestate',
+                    "string:%s" % state
+                    ])
+        except Exception as e:
+            self.logger.warn('failed to start dbus-send process: %s' % e)
+
+
     def move_mouse(self, x, y, reference='absolute', proportional=False,
                    phantom=None, _xdotool=None):
         '''move the mouse to the specified coordinates. reference may be one


### PR DESCRIPTION
Adding the following Python code to a NatLink macro module allows for
the host to receive notifications about the microphone state.

    import aenea
    import natlink

    # Notify on change
    def changeCallback(cbType, args):
        if cbType == 'mic':
            ProxyNotification("dragon mic: %s" % args).execute()
            aenea.communications.server.micState(args)

    # Send the current state on startup
    aenea.communications.server.micState(natlink.getMicState())

Dbus integration can be used with a simple Python3 program as follows:

    import dbus
    import dbus.service

    from dbus.mainloop.glib import DBusGMainLoop
    DBusGMainLoop(set_as_default=True)
    import gi
    from gi.repository import GLib
    from pprint import pprint

    def state_handler(state):
        global mic_state
        state = str(state)
        if state in ['on', 'sleeping', 'off', 'disabled']:
            print("microphone is: %s" % state)
        else:
            print("microphone is mysteriously: %s" % state)

    loop = GLib.MainLoop()

    bus = dbus.SessionBus()

    bus.add_signal_receiver(state_handler,
                            dbus_interface='dictationtoolbox.aenea',
                            signal_name='microphonestate')

    loop.run()