### PR TITLE
Add security token to the plugin example.

### DIFF
--- a/server/linux_x11/plugins/example.py
+++ b/server/linux_x11/plugins/example.py
@@ -3,7 +3,7 @@ from yapsy.IPlugin import IPlugin
 enabled = True
 
 
-def greet_user(name='Incognito'):
+def greet_user(name='Incognito', security_token=''):
     '''RPC command to greet a user. See the _server_plugin_example grammar for
        how to use on the client side via voice.'''
     print 'Hello user %s!' % name


### PR DESCRIPTION
If you use security tokens, then aenea server plugins crash with the error message "TypeError: greet_user() takes at most 1 argument (2 given)". But an easy fix is to add an optional arg to the end of every server plugin.